### PR TITLE
fix invalid printf format

### DIFF
--- a/lib/bench_command.ml
+++ b/lib/bench_command.ml
@@ -50,7 +50,7 @@ let spec () =
     +> flag "-linear" (optional int)
          ~doc:"INCREMENT Use linear sampling to explore number of runs, example 1."
     +> flag "-geometric" (optional float)
-         ~doc:(sprintf "SCALE Use geometric sampling. (default %0.2f)"
+         ~doc:(sprintf "SCALE Use geometric sampling. (default %.2f)"
                  Defaults.geometric_scale)
     +> flag "-save" no_arg ~doc:" Save benchmark data to <test name>.txt files."
     +> flag "-ascii" no_arg ~doc:" Display data in simple ascii based tables."


### PR DESCRIPTION
There is a format string that is "invalid" in the core_bench sources.

In general, invalid formats are nonsensical format strings that were accepted in OCaml 4.01.0 and earlier, but whose semantics is unspecified. They are still accepted by the new Printf implementation of OCaml 4.02.0 but in some cases with different semantics, and they will be statically rejected by OCaml 4.03.0.

You can check for them in OCaml 4.02.0 with the flag -strict-formats.

In the case of core_bench, I think the behavior has not changed between 4.01.0 and 4.02.0. The only invalid format is "%0.2f". This is considered invalid beause it specifies a padding character (with the flag 0), but no minimum field width (no number before the dot) so there will never be padding. Even though the behaviour has not changed, you should take the opportunity to review the code and fix the format. The patch changes it to "%.2f", which keeps the behaviour unchanged, but that might not be the intended behaviour.
