### PR TITLE
Added lost `Str` dependency

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -66,7 +66,8 @@ Library inline_benchmarks
   BuildDepends:       core_bench,
                       sexplib.syntax,
                       fieldslib.syntax,
-                      comparelib.syntax
+                      comparelib.syntax,
+                      str
   XMETARequires:      core_bench
 
 Executable test_bench


### PR DESCRIPTION
Without this dependency program linked with `inline_benchmarks` runner fail to compile with something like this:

```
/home/ivg/.opam/4.01.0+PIC/bin/ocamlfind ocamlopt -g -linkpkg -package bin_prot.syntax -package camlp4 -package comparelib.syntax -package core -package core_bench.inline_benchmarks -package core_kernel -package fieldslib.syntax -package herelib.syntax -package pa_bench.syntax -package pa_ounit.syntax -package sexplib.syntax -package threads -package variantslib.syntax -thread lib_test/bap/run_benchmarks.cmx -o lib_test/bap/run_benchmarks.native
+ /home/ivg/.opam/4.01.0+PIC/bin/ocamlfind ocamlopt -g -linkpkg -package bin_prot.syntax -package camlp4 -package comparelib.syntax -package core -package core_bench.inline_benchmarks -package core_kernel -package fieldslib.syntax -package herelib.syntax -package pa_bench.syntax -package pa_ounit.syntax -package sexplib.syntax -package threads -package variantslib.syntax -thread lib_test/bap/run_benchmarks.cmx -o lib_test/bap/run_benchmarks.native
File "_none_", line 1:
Error: No implementations provided for the following modules:
         Str referenced from /home/ivg/.opam/4.01.0+PIC/lib/core_bench/inline_benchmarks.cmxa(Inline_benchmarks)
```
