### PR TITLE
Fix marshalling causing crashes with using the `-fork` flag.

### DIFF
--- a/internals/measurement_sample.ml
+++ b/internals/measurement_sample.ml
@@ -10,7 +10,7 @@ type t =
   ; mutable promoted : int
   ; mutable major_collections : int
   ; mutable minor_collections : int
-  ; mutable extra : float String.Map.t
+  ; mutable extra : (string * float) list
   }
 [@@deriving sexp, fields ~getters ~iterators:fold]
 
@@ -24,7 +24,7 @@ let create () =
   ; promoted = 0
   ; major_collections = 0
   ; minor_collections = 0
-  ; extra = String.Map.empty
+  ; extra = []
   }
 ;;
 
@@ -63,7 +63,7 @@ let field_values_to_string t =
     ~promoted:prepend_int
     ~extra:(fun xs extra ->
       let extra = Field.get extra t in
-      assert (Map.is_empty extra);
+      assert (List.is_empty extra);
       xs)
   |> List.rev
   |> String.concat ~sep:","
@@ -125,5 +125,5 @@ let accessor = function
   | `Major_allocated -> floatify_int major_allocated
   | `Promoted -> floatify_int promoted
   | `One -> fun _ -> 1.
-  | `Extra str -> fun t -> Map.find_exn t.extra str
+  | `Extra str -> fun t -> List.Assoc.find_exn t.extra ~equal:String.equal str
 ;;

--- a/internals/measurement_sample.mli
+++ b/internals/measurement_sample.mli
@@ -13,7 +13,7 @@ type t =
   ; mutable promoted : int
   ; mutable major_collections : int
   ; mutable minor_collections : int
-  ; mutable extra : float String.Map.t
+  ; mutable extra : (string * float) list
   }
 [@@deriving sexp]
 


### PR DESCRIPTION
When testing on MacOS I was running my benchmarks with the `-fork` flag.
This causes every benchmark to throw an exception with:
```
Uncaught exception:
  
  (Invalid_argument "output_value: functional value")

Raised by primitive operation at Stdlib__Marshal.(partial) in file "marshal.ml" (inlined), lines 28-29, characters 0-93
Called from Core_bench__Benchmark.measure_all.(fun) in file "src/benchmark.ml", line 232, characters 12-38
Called from Stdlib__List.iter2 in file "list.ml" (inlined), line 160, characters 24-31``
```

It appears that when using `-fork`, each measurement is marshalled over a pipe.
However measurements have samples and their samples include an `extra` field which can't be marshalled.

```ocaml
match Caml_unix.fork () with
| 0 ->
  let x = measure run_config test in
  let open Stdlib in
  let oc = Caml_unix.out_channel_of_descr fdw in
  Marshal.to_channel oc x []; (* This fails to marshall. *)
  exit 0
| pid -> ignore (Caml_unix.waitpid [] pid : int * Caml_unix.process_status))
```

I've changed the samples using a `Map` to just using an association list which fixes the issue.
